### PR TITLE
Feature sticky table header

### DIFF
--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -2,3 +2,8 @@
 .report tbody tr:nth-child(1n+2) td:nth-child(2) span {
   visibility: hidden;
 }
+
+.report-sticky {
+  position: sticky;
+  top: 0;
+}

--- a/src/web/views/report.pug
+++ b/src/web/views/report.pug
@@ -1,7 +1,7 @@
 extends layout.pug
 
 block content
-  .container-fluid
+  .container
     .row
       .form.m-3
         .form-row.align-items-center
@@ -30,14 +30,14 @@ block content
       table.table.table-bordered.report
         thead.thead-dark
           tr
-            th Date
-            th Department
-            th Name
-            th Position
-            th Work Start
-            th Work End
-            th Lunch Start
-            th Lunch End
+            th.report-sticky Date
+            th.report-sticky Department
+            th.report-sticky Name
+            th.report-sticky Position
+            th.report-sticky Work Start
+            th.report-sticky Work End
+            th.report-sticky Lunch Start
+            th.report-sticky Lunch End
 
         each val, key in report
           -var date = key


### PR DESCRIPTION
When scrolling, pin the report table header to the top of the browser
window.

[Trello](https://trello.com/c/9V2orSg0/2-sticky-header-in-report)