### PR TITLE
feature: prefill times

### DIFF
--- a/src/intents/find-all-agents-in-latest-report.js
+++ b/src/intents/find-all-agents-in-latest-report.js
@@ -4,7 +4,9 @@ module.exports = async function findAllAgentsInLatestReport ({
   project,
   department,
 }) {
-  const [{ date }] = await getLatestReportDate({ project: project.id, department })
+  const rawDate = await getLatestReportDate({ project: project.id, department })
+  if (!rawDate.length) return
+  const [{ date }] = rawDate
 
   const agents = await getAgentsInReport({
     project: project.id,

--- a/src/views/scripts/time-record-script.js
+++ b/src/views/scripts/time-record-script.js
@@ -44,6 +44,19 @@ function createNewAgent (template, { index, name = '', position = '' }) {
 
   agentsList.append(tmpl)
 
+  const workStart = $('.js-prefilled-work-start').val()
+  const workStop = $('.js-prefilled-work-stop').val()
+  const lunchStart = $('.js-prefilled-lunch-start').val()
+  const lunchStop = $('.js-prefilled-lunch-stop').val()
+
+  const target = $('.js-agent')[i]
+  if (workStart) $(target).find('.js-work-start').val(workStart)
+  if (workStop) $(target).find('.js-work-stop').val(workStop)
+  if (lunchStart) $(target).find('.js-lunch-start').val(lunchStart)
+  if (lunchStop) $(target).find('.js-lunch-stop').val(lunchStop)
+
+  calculateWorkTime({ target })
+
   return tmpl
 }
 
@@ -181,6 +194,57 @@ function renumberOrderables () {
   })
 }
 
+function prefillTimes (e) {
+  e.preventDefault()
+
+  const workStart = $('.js-prefilled-work-start').val()
+  const workStop = $('.js-prefilled-work-stop').val()
+  const lunchStart = $('.js-prefilled-lunch-start').val()
+  const lunchStop = $('.js-prefilled-lunch-stop').val()
+
+  const altered = new Set()
+
+  if (workStart) {
+    $('.js-work-start').each(function () {
+      if ($(this).val() === '') {
+        $(this).val(workStart)
+        altered.add($(this).closest('.js-agent')[0])
+      }
+    })
+  }
+
+  if (workStop) {
+    $('.js-work-stop').each(function () {
+      if ($(this).val() === '') {
+        $(this).val(workStop)
+        altered.add($(this).closest('.js-agent')[0])
+      }
+    })
+  }
+
+  if (lunchStart) {
+    $('.js-lunch-start').each(function () {
+      if ($(this).val() === '') {
+        $(this).val(lunchStart)
+        altered.add($(this).closest('.js-agent')[0])
+      }
+    })
+  }
+
+  if (lunchStop) {
+    $('.js-lunch-stop').each(function () {
+      if ($(this).val() === '') {
+        $(this).val(lunchStop)
+        altered.add($(this).closest('.js-agent')[0])
+      }
+    })
+  }
+
+  altered.forEach((target) => {
+    calculateWorkTime({ target })
+  })
+}
+
 $(document).ready(() => {
   const template = $('.js-agent-template')
 
@@ -216,4 +280,15 @@ $(document).ready(() => {
 
   bindDeleteRecordButton()
   bindNoCallButton()
+
+  $('.js-prefill-times').click(prefillTimes)
+
+  $('.js-clear-timesheet').click(function (e) {
+    e.preventDefault()
+
+    const result = confirm('Remove all entries?')
+    if (result) {
+      $('.js-agent').remove()
+    }
+  })
 })

--- a/src/views/time-record.pug
+++ b/src/views/time-record.pug
@@ -57,6 +57,29 @@ block content
         input.form-control(type="date", value= date, name="date", required)
         small.form-text.text-muted
 
+    .card.my-3.d-flex.flex-row
+      .d-flex.justify-content-center.align-items-center.flex-grow-1.bg-light
+        div Prefill Times
+      .flex-grow-1
+        .form-floating.m-2.m-md-0
+          input.px-lg-1.px-xl-3.border-0.form-control.js-prefilled-work-start(formnovalidate, pattern="([0-4][0-9][0-5][0-9]|[nN]\/[cC])", placeholder="0700")
+          label.px-lg-1.px-xl-3 Work Start
+      .flex-grow-1
+        .form-floating.m-2.m-md-0
+          input.px-lg-1.px-xl-3.border-0.form-control.js-prefilled-lunch-start(formnovalidate, pattern="([0-4][0-9][0-5][0-9]|[nN]\/[cC])", placeholder="1300")
+          label.px-lg-1.px-xl-3 Lunch Start
+      .flex-grow-1
+        .form-floating.m-2.m-md-0
+          input.px-lg-1.px-xl-3.border-0.form-control.js-prefilled-lunch-stop(formnovalidate, pattern="([0-4][0-9][0-5][0-9]|[nN]\/[cC])", placeholder="1400")
+          label.px-lg-1.px-xl-3 Lunch Stop
+      .flex-grow-1
+        .form-floating.m-2.m-md-0
+          input.px-lg-1.px-xl-3.border-0.form-control.js-prefilled-work-stop(formnovalidate, pattern="([0-4][0-9][0-5][0-9]|[nN]\/[cC])", placeholder="2100")
+          label.px-lg-1.px-xl-3 Work End
+      .flex-grow-1.d-flex.justify-content-end
+        button.btn.btn-primary.js-prefill-times(formnovalidate data-bs-toggle="tooltip" data-bs-placement="top" title="Update times")
+          span Fill empty times
+
     .js-agents
         if entries
           each entry, index in entries
@@ -76,7 +99,7 @@ block content
     .row
       .col-12.my-3.text-center
         input.btn.btn-block.btn-primary.me-2.my-1(type="submit" value="Review TimeSheet")
-        input.btn.btn-block.btn-outline-secondary.me-2.my-1(type="reset" value="Clear TimeSheet")
+        input.btn.btn-block.btn-outline-secondary.me-2.my-1.js-clear-timesheet(type="reset" value="Clear TimeSheet")
 
     if user.isCrew && !user.isAdmin
       input(value= user.department, name="department", required, readonly, hidden)


### PR DESCRIPTION
Adds functionality that prefills time slots on each agent if they are
not previously filled (don't overwrite existing values).
New agents created after prefill values are populated, will be filled
with the prefill and have their time calculated.
Using the fill empty times button will fill all missing values