### PR TITLE
fix: persist time record position for agent

### DIFF
--- a/migrations/20220128151400_alter_time_records.js
+++ b/migrations/20220128151400_alter_time_records.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable('time_records', (table) => {
+    table.text('position')
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.alterTable('time_records', (table) => {
+    table.dropColumn('position')
+  })
+}

--- a/src/components/time-record.js
+++ b/src/components/time-record.js
@@ -12,6 +12,7 @@ const schema = OBJECT
   .prop('lunchStart', STRING)
   .prop('lunchStop', STRING)
   .prop('order', NUMBER).required()
+  .prop('position', STRING).required()
 
 module.exports = class TimeRecord extends Model {
   static tableName = 'time_records'

--- a/src/components/time-report.js
+++ b/src/components/time-report.js
@@ -11,8 +11,9 @@ exports.findAll = async function findAll ({ project, date, department }) {
       'timeRecords.lunchStart as lunchStart',
       'timeRecords.lunchStop as lunchStop',
       'timeRecords.order as order',
+      'timeRecords.position as recordPosition',
       'agents.name as name',
-      'agents.position as position',
+      'agents.position as agentPosition',
     )
     .leftJoin('departments', 'departments.id', 'timeRecords.department')
     .leftJoin('agents', 'agents.id', 'timeRecords.agent')
@@ -30,6 +31,7 @@ exports.findAll = async function findAll ({ project, date, department }) {
       'timeRecords.lunchStart',
       'timeRecords.lunchStop',
       'timeRecords.order',
+      'timeRecords.position',
       'agents.name',
       'agents.position',
     )

--- a/src/intents/find-all-agents-in-latest-report.js
+++ b/src/intents/find-all-agents-in-latest-report.js
@@ -18,7 +18,7 @@ module.exports = async function findAllAgentsInLatestReport ({
     .filter((agent) => agent._agent)
     .map((agent) => ({
       name: agent._agent.name,
-      position: agent._agent.position,
+      position: (agent.position || agent._agent.position),
       department: agent._agent.department,
       order: agent.order,
     }))
@@ -37,7 +37,7 @@ async function getLatestReportDate ({ project, department }) {
 
 async function getAgentsInReport ({ project, department, date }) {
   return TimeRecord.query()
-    .select('timeRecords.order')
+    .select(['timeRecords.order', 'timeRecords.position'])
     .distinct(['timeRecords.agent'])
     .withGraphJoined('_agent')
     .where(async (builder) => {

--- a/src/views/report.pug
+++ b/src/views/report.pug
@@ -54,7 +54,7 @@ block content
                           td
                             span= departmentName
                       td= entry.name
-                      td= entry.position
+                      td= (entry.recordPosition || entry.agentPosition)
                       td= entry.workStart
                       td= `${entry.lunchStart} - ${entry.lunchStop}`
                       td= entry.workStop

--- a/src/views/time-record-receipt.pug
+++ b/src/views/time-record-receipt.pug
@@ -2,8 +2,8 @@ extends layout.pug
 
 mixin record(record)
   tr
-    td= record.agent.name
-    td= record.agent.position
+    td= record.name
+    td= record.position
     td= record.workStart
     td= record.lunchStart
     td= record.lunchStop


### PR DESCRIPTION
Adds a position column to the time records table which will be used to
store the position on the dtr form. Previously we pulled the position of
the agent from their initial entry into the system.